### PR TITLE
Fix for issue #4

### DIFF
--- a/background.js
+++ b/background.js
@@ -73,7 +73,13 @@ chrome.browserAction.onClicked.addListener(function() {
   configuration.get('iconClickURL', function(url) {
     const basename = validURL(url) ? getBasename(url) : defaultURL
 
-    chrome.tabs.create({ url: 'https://' + basename })
+    chrome.tabs.query({ url: 'https://' + basename + '/*' }, function(tabs) {
+      if (tabs && tabs.length) {
+        chrome.tabs.update(tabs[0].id, { selected: true, active: true })
+      } else {
+        chrome.tabs.create({ url: 'https://' + basename })
+      }
+    })
   })
 
   function validURL(url) {

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,6 @@
     "persistent": false
   },
   "options_page": "options/options.html",
-  "permissions": ["storage", "notifications"],
+  "permissions": ["storage", "notifications", "tabs"],
   "content_security_policy": "default-src 'self'; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; img-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net data:"
 }


### PR DESCRIPTION
https://github.com/NicoSantangelo/hangouts-chrome-notifications/issues/4
Query tabs to check if hangouts tab is already open before creating a new one from extension button.
Also added "tabs" permission to allow calling tabs.query with url parameter.